### PR TITLE
ci: run Go workflow only on Go-related changes

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -12,6 +12,7 @@ on:
       - '**.go'
       - 'go.mod'
       - 'go.sum'
+      - '.golangci.yml'
       - '.github/workflows/go.yaml'
       - '.github/actions/**'
 
@@ -21,6 +22,7 @@ on:
       - '**.go'
       - 'go.mod'
       - 'go.sum'
+      - '.golangci.yml'
       - '.github/workflows/go.yaml'
       - '.github/actions/**'
 

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -8,9 +8,21 @@ name: Go
 on:
   push:
     branches: [ "main", "release/**" ]
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/go.yaml'
+      - '.github/actions/**'
 
   pull_request:
     branches: [ "main", "release/**" ]
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/go.yaml'
+      - '.github/actions/**'
 
   workflow_dispatch:
 


### PR DESCRIPTION
## What this does

Makes the **Go** CI workflow (build, test, lint) run **only when Go-related files actually change** — instead of on every single push and pull request.

## Why

Right now the Go workflow runs even when a change touches nothing that Go cares about — for example editing the `README.md`, docs, or an unrelated config file. Those runs:

- waste CI minutes and compute,
- add slow, unnecessary checks to PRs that don't need them,
- clutter the checks list with results that were never going to be affected.

This change scopes the workflow so it triggers only when it's meaningful.

## How

Added `paths:` filters to the `push` and `pull_request` triggers in `.github/workflows/go.yaml`. The workflow now runs when any of these change:

| Path | Why it matters |
|------|----------------|
| `**.go` | Any Go source file |
| `go.mod` / `go.sum` | Dependency changes |
| `.golangci.yml` | Lint rule changes (so the lint job re-runs) |
| `.github/workflows/go.yaml` | The workflow itself |
| `.github/actions/**` | Shared CI actions it depends on |

If a change touches none of these (e.g. docs only), the Go workflow is skipped.

## Impact

- **No change** to what the workflow does when it runs — same build, test, and lint steps.
- **Faster PRs** for non-Go changes, and less wasted CI.
- `workflow_dispatch` is kept, so the workflow can always be triggered manually if needed.
