### PR TITLE
fix: address cli issues discovered during code audit

### DIFF
--- a/internal/README.md
+++ b/internal/README.md
@@ -27,13 +27,13 @@ Verify the download against the `checksums.txt` published with the release.
 
 ## Global Flags
 
-These apply to every client-mode command. Each command selects the agent it talks to with either `--agent-card` (resolve a card) or `--url` (connect to an interface directly).
+These apply to every client-mode command. Each command selects the agent it talks to with either `--agent-card` (resolve a card) or `--endpoint` (connect to an interface directly).
 
 | Flag | Short | Description |
 |---|---|---|
 | `--agent-card <ref>` | `-a` | Agent Card reference: a host/origin (the well-known path is appended), a full card URL, or a local file path. The card is resolved and a transport negotiated. |
-| `--url <ref>` | `-u` | Agent interface URL for a direct connection, skipping card resolution. Must be paired with exactly one `--transport`. Mutually exclusive with `--agent-card`. |
-| `--transport <name>` | | Transport preference: `rest`, `jsonrpc`, `grpc`. Repeatable and ordered (highest preference first). With `--agent-card` it overrides the card's preference order; with `--url` exactly one is required. |
+| `--endpoint <ref>` | `-e` | Agent interface URL for a direct connection, skipping card resolution. Must be paired with exactly one `--transport`. Mutually exclusive with `--agent-card`. |
+| `--transport <name>` | | Transport preference: `rest`, `jsonrpc`, `grpc`. Repeatable and ordered (highest preference first). With `--agent-card` it overrides the card's preference order; with `--endpoint` exactly one is required. |
 | `--output <fmt>` | `-o` | Output format: `text` (default), `json`. |
 | `--svc-param <k=v>` | | Service parameter (repeatable). The chosen transport defines how it's passed. Split on the first `=`. |
 | `--auth <creds>` | | Shorthand for `--svc-param "Authorization=<creds>"`. |
@@ -123,7 +123,7 @@ positional argument is shorthand for a single `--text-part` part.
 a2a send -a <url> "Hello, what can you do?"
 
 # Connect directly to an interface, skipping card resolution
-a2a send -u <url> --transport rest "Hello, what can you do?"
+a2a send -e <url> --transport rest "Hello, what can you do?"
 
 # Multiple ordered parts: text, an inlined local file, and a referenced URL
 a2a send -a <url> --text-part "Review this" --file-part report.pdf --media-type application/pdf --file-part https://example.com/spec.pdf
@@ -212,7 +212,7 @@ Streams events to stdout until the task reaches a terminal state. Output format 
 
 ## Server Mode
 
-`a2a serve` starts an A2A-compliant server backed by one of three modes.
+`a2a server` starts an A2A-compliant server backed by one of three modes.
 
 ### Common Server Flags
 
@@ -222,7 +222,9 @@ Streams events to stdout until the task reaches a terminal state. Output format 
 | `--host <addr>` | Bind address. Default `127.0.0.1`. |
 | `--name <name>` | Agent name for the auto-generated card. |
 | `--description <desc>` | Agent description. |
-| `--transport <proto>` | Transport to serve: `rest` (default), `jsonrpc`, `grpc`. |
+| `--serve-transport <proto>` | Transport to serve: `rest` (default), `jsonrpc`, `grpc`. |
+| `--advertise-address <addr>` | Endpoint advertised in the served agent card. Defaults to the listener address. |
+| `--insecure` | Use insecure (plaintext) gRPC transport credentials (proxy upstream). |
 | `--protocol <ver>` | Protocol version: `latest` (default), `0.3`. When set to `0.3`, the server uses the compat transport layer (`a2agrpc/v0` for gRPC, `a2acompat/a2av0` for REST/JSON-RPC) to accept v0.3 clients. |
 | `--card <file>` | Serve a custom agent card JSON instead of auto-generating. |
 | `--card-compat` | Serve the agent card in a dual v0.3/v1.0 format so both old and new clients can discover the agent. |
@@ -231,24 +233,24 @@ Streams events to stdout until the task reaches a terminal state. Output format 
 ### `--echo` - Echo Mode
 
 ```bash
-a2a serve --echo
-a2a serve --echo --port 9090 --name "Echo Agent"
+a2a server --echo
+a2a server --echo --port 9090 --name "Echo Agent"
 ```
 Returns the user's message text as the agent response. A "ping" for agents — useful for connectivity testing and client development.
 
 ### `--proxy` - Proxy Mode
 
-Forward all requests to an upstream A2A agent. Logs traffic to stderr. Useful for debugging agent interactions, injecting service parameters, or acting as an authenticated gateway.
+Forward all requests to an upstream A2A agent. Logs traffic to stderr. Useful for debugging agent interactions, injecting service parameters, or acting as an authenticated gateway. `--proxy` is a boolean flag; the upstream agent is selected with the global `-a, --agent-card` or `-e, --endpoint` flags.
 
 ```bash
 # Basic proxy with traffic logging
-a2a serve --proxy https://upstream-agent.com
+a2a server --proxy -a https://upstream-agent.com
 
 # Inject auth for an upstream that requires it
-a2a serve --proxy https://upstream-agent.com --auth "<token>"
+a2a server --proxy -a https://upstream-agent.com --auth "<token>"
 
 # Add tracing headers
-a2a serve --proxy https://upstream-agent.com \
+a2a server --proxy -a https://upstream-agent.com \
   --svc-param "X-Request-Source=a2a-proxy" \
   --svc-param "X-Trace-ID=debug-session-1"
 ```
@@ -259,8 +261,8 @@ The proxy creates an `a2aclient.Client` for the upstream agent and forwards each
 
 Run any command as an A2A agent. Message text goes to stdin, stdout becomes the response artifact. The subprocess does not need to know anything about A2A.
 ```bash
-a2a serve --exec "python -u a2a_unaware_agent.py"
-a2a serve --exec "./content-generator.sh"
+a2a server --exec "python -u a2a_unaware_agent.py"
+a2a server --exec "./content-generator.sh"
 ```
 
 #### Subprocess Interface
@@ -284,13 +286,13 @@ Status: working → [process runs] → Artifact (full output) → Status: comple
 
 ```bash
 # Emit 3 chunks with 500ms delay - useful for verifying client streaming
-a2a serve --exec "for i in 1 2 3; do echo \$i; sleep 0.5; done" --chunk=$'\n'
+a2a server --exec "for i in 1 2 3; do echo \$i; sleep 0.5; done" --chunk=$'\n'
 
 # Space-delimited chunks
-a2a serve --exec "echo 'alpha beta gamma'" --chunk=' '
+a2a server --exec "echo 'alpha beta gamma'" --chunk=' '
 
 # Paragraph-level chunks
-a2a serve --exec "cat essay.txt" --chunk=$'\n\n'
+a2a server --exec "cat essay.txt" --chunk=$'\n\n'
 ```
 
 The event sequence with `--chunk`:

--- a/internal/cli/card_get.go
+++ b/internal/cli/card_get.go
@@ -37,12 +37,16 @@ func newCardGetCmd(cfg *globalConfig) *cobra.Command {
 			ctx, cancel := context.WithTimeout(ctx, cfg.timeout)
 			defer cancel()
 
+			if len(args) == 1 {
+				cfg.agentCard = args[0]
+			}
+
 			var card *a2a.AgentCard
 			var err error
 			if extended {
 				card, err = getExtendedAgentCard(ctx, cfg)
 			} else {
-				card, err = getPublicAgentCard(ctx, cfg, args)
+				card, err = getPublicAgentCard(ctx, cfg)
 			}
 			if err != nil {
 				return err
@@ -65,11 +69,7 @@ func getExtendedAgentCard(ctx context.Context, cfg *globalConfig) (*a2a.AgentCar
 	if err != nil {
 		return nil, fmt.Errorf("failed to create a client: %w", err)
 	}
-	defer func() {
-		if err := client.Destroy(); err != nil {
-			cfg.logf("failed to destroy client: %v", err)
-		}
-	}()
+	defer destroyClient(cfg, client)
 
 	card, err := client.GetExtendedAgentCard(ctx, &a2a.GetExtendedAgentCardRequest{Tenant: cfg.tenant})
 	if err != nil {
@@ -78,11 +78,8 @@ func getExtendedAgentCard(ctx context.Context, cfg *globalConfig) (*a2a.AgentCar
 	return card, nil
 }
 
-func getPublicAgentCard(ctx context.Context, cfg *globalConfig, args []string) (*a2a.AgentCard, error) {
+func getPublicAgentCard(ctx context.Context, cfg *globalConfig) (*a2a.AgentCard, error) {
 	ref := cfg.agentCard
-	if len(args) == 1 {
-		ref = args[0]
-	}
 	if ref == "" {
 		return nil, fmt.Errorf("specify the agent card URL as an argument or with --agent-card")
 	}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -106,6 +106,17 @@ func TestCardGet(t *testing.T) {
 			t.Fatal("a2a card get (no url) should fail")
 		}
 	})
+
+	t.Run("extended with positional url", func(t *testing.T) {
+		t.Parallel()
+		_, err := runCMD(t, "card", "get", url, "--extended")
+		if err == nil {
+			t.Fatal("card get <url> --extended against a server without an extended card should fail")
+		}
+		if strings.Contains(err.Error(), "must be provided") {
+			t.Fatalf("card get <url> --extended ignored the positional url: %v", err)
+		}
+	})
 }
 
 func TestVersion(t *testing.T) {
@@ -288,14 +299,14 @@ func TestBuildMessage(t *testing.T) {
 
 	t.Run("more than one positional is an error", func(t *testing.T) {
 		t.Parallel()
-		if _, err := buildMessage([]string{"one", "two"}, &flagparse.Parts{}); err == nil {
+		if _, err := buildMessage([]string{"one", "two"}, &sendFlags{}); err == nil {
 			t.Fatal("buildMessage() with multiple positional args should fail")
 		}
 	})
 
 	t.Run("no content is an error", func(t *testing.T) {
 		t.Parallel()
-		if _, err := buildMessage(nil, &flagparse.Parts{}); err == nil {
+		if _, err := buildMessage(nil, &sendFlags{}); err == nil {
 			t.Fatal("buildMessage() with no content should fail")
 		}
 	})
@@ -348,7 +359,7 @@ func TestParseRequestPayload(t *testing.T) {
 	})
 }
 
-func partsFromArgs(t *testing.T, args ...string) *flagparse.Parts {
+func partsFromArgs(t *testing.T, args ...string) *sendFlags {
 	t.Helper()
 	var p flagparse.Parts
 	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
@@ -356,7 +367,7 @@ func partsFromArgs(t *testing.T, args ...string) *flagparse.Parts {
 	if err := fs.Parse(args); err != nil {
 		t.Fatalf("fs.Parse(%v) error = %v", args, err)
 	}
-	return &p
+	return &sendFlags{parts: p}
 }
 
 func TestSendStreaming(t *testing.T) {
@@ -422,6 +433,30 @@ func TestSendStreaming(t *testing.T) {
 	}
 }
 
+func TestSendStreamingFallbackUsesDefaultPoller(t *testing.T) {
+	t.Parallel()
+	nonStreamingURL := startTestServerWith(t, a2a.AgentCapabilities{Streaming: false})
+
+	out, err := runCMDWithConfig(t, deps{cfgLoader: clicfg.LoadEmpty},
+		"send", "-a", nonStreamingURL, "-o", "json", "--stream", "stream me", "--polling-interval", "5ms")
+	if err != nil {
+		t.Fatalf("runCMDWithConfig() error = %v", err)
+	}
+
+	dec := json.NewDecoder(strings.NewReader(out))
+	events := 0
+	for dec.More() {
+		var sr a2a.StreamResponse
+		if err := dec.Decode(&sr); err != nil {
+			t.Fatalf("json.Decode(event %d) error = %v", events, err)
+		}
+		events++
+	}
+	if events == 0 {
+		t.Fatalf("send --stream via default poller produced %d events, want > 0", events)
+	}
+}
+
 func TestGetTask(t *testing.T) {
 	t.Parallel()
 	url := startTestServer(t)
@@ -469,16 +504,21 @@ func TestGetTask(t *testing.T) {
 func TestServe_ModeValidation(t *testing.T) {
 	t.Parallel()
 	for _, tt := range []struct {
-		name string
-		args []string
+		name           string
+		args           []string
+		wantErrContain string
 	}{
-		{"no mode", []string{"serve"}},
-		{"multiple modes", []string{"serve", "--echo", "--exec", "cat"}},
+		{"no mode", []string{"server"}, "specify --echo, --proxy <url>, or --exec"},
+		{"multiple modes", []string{"server", "--echo", "--exec", "cat"}, "mutually exclusive"},
 	} {
 		t.Run(tt.name+" fails", func(t *testing.T) {
 			t.Parallel()
-			if _, err := runCMD(t, tt.args...); err == nil {
-				t.Fatal("expected error")
+			_, err := runCMD(t, tt.args...)
+			if err == nil {
+				t.Fatalf("runCMD(%v) error = nil, want error containing %q", tt.args, tt.wantErrContain)
+			}
+			if !strings.Contains(err.Error(), tt.wantErrContain) {
+				t.Fatalf("runCMD(%v) error = %v, want error containing %q", tt.args, err, tt.wantErrContain)
 			}
 		})
 	}

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -139,3 +139,9 @@ func withServiceParams(ctx context.Context, cfg *globalConfig) context.Context {
 	}
 	return ctx
 }
+
+func destroyClient(cfg *globalConfig, client *a2aclient.Client) {
+	if err := client.Destroy(); err != nil {
+		cfg.logf("failed to destroy client: %v", err)
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -82,6 +82,8 @@ func Execute() int {
 }
 
 func newRootCmd(cfg *globalConfig, deps deps) *cobra.Command {
+	deps.setDefaults()
+
 	cmd := &cobra.Command{
 		Use:           "a2a",
 		Short:         "CLI for the Agent-to-Agent protocol",
@@ -89,8 +91,6 @@ func newRootCmd(cfg *globalConfig, deps deps) *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			deps.setDefaults()
-
 			store, err := deps.cfgLoader(clicfg.LoadOpts{ConfigPath: cfg.configPath})
 			if err != nil {
 				return err

--- a/internal/cli/send.go
+++ b/internal/cli/send.go
@@ -25,99 +25,75 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/a2aproject/a2a-cli/internal/flagparse"
+	"github.com/a2aproject/a2a-cli/internal/utils"
 	"github.com/a2aproject/a2a-go/v2/a2a"
 	"github.com/a2aproject/a2a-go/v2/a2aclient"
 )
 
+type sendFlags struct {
+	stream          bool
+	async           bool
+	payload         string
+	taskID          string
+	contextID       string
+	history         int
+	pollingInterval time.Duration
+	parts           flagparse.Parts
+	meta            flagparse.Metadata
+}
+
 type pollerFunc func(ctx context.Context, client *a2aclient.Client, req *a2a.SendMessageRequest, interval time.Duration) iter.Seq2[a2a.Event, error]
 
 func newSendCmd(cfg *globalConfig, poller pollerFunc) *cobra.Command {
-	var (
-		stream          bool
-		async           bool
-		payload         string
-		taskID          string
-		contextID       string
-		history         int
-		pollingInterval time.Duration
-		parts           flagparse.Parts
-		meta            flagparse.Metadata
-	)
+	var flags sendFlags
 
 	cmd := &cobra.Command{
 		Use:   "send [message]",
 		Short: "Send a message to an agent",
 		Args:  cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if stream && async {
+			if flags.stream && flags.async {
 				return fmt.Errorf("--stream is incompatible with --async")
 			}
+			baseCtx := withServiceParams(cmd.Context(), cfg)
 
-			var req *a2a.SendMessageRequest
-			if payload != "" {
-				if err := ensureNoPayloadOverrides(cmd, args); err != nil {
-					return err
-				}
-				parsed, err := parseRequestPayload(payload)
-				if err != nil {
-					return err
-				}
-				req = parsed
-			} else {
-				msg, err := buildMessage(args, &parts)
-				if err != nil {
-					return err
-				}
-				if taskID != "" {
-					msg.TaskID = a2a.TaskID(taskID)
-				}
-				if contextID != "" {
-					msg.ContextID = contextID
-				}
-				req = &a2a.SendMessageRequest{Message: msg}
-				meta.ApplyTo(req)
-				if async || cmd.Flags().Changed("history") {
-					req.Config = &a2a.SendMessageConfig{}
-					if async {
-						req.Config.ReturnImmediately = true
-					}
-					if cmd.Flags().Changed("history") {
-						req.Config.HistoryLength = &history
-					}
-				}
-			}
-			if req.Tenant == "" {
-				req.Tenant = cfg.tenant
+			req, err := buildRequest(cmd, cfg, &flags, args)
+			if err != nil {
+				return err
 			}
 
-			ctx, cancel := context.WithTimeout(cmd.Context(), cfg.timeout)
-			defer cancel()
-			ctx = withServiceParams(ctx, cfg)
-
+			ctx, cancel := context.WithTimeout(baseCtx, cfg.timeout)
 			client, err := newAgentClient(ctx, cfg)
 			if err != nil {
 				return fmt.Errorf("failed to create a client: %w", err)
 			}
-			defer func() {
-				if err := client.Destroy(); err != nil {
-					cfg.logf("failed to destroy client: %v", err)
-				}
-			}()
+			cancel()
+			defer destroyClient(cfg, client)
 
-			if stream {
-				if err := handleStreaming(ctx, cfg, client, req); err != nil {
-					if !errors.Is(err, a2a.ErrUnsupportedOperation) {
-						return err
-					}
-					cfg.logf("falling back to polling (%v): %v", pollingInterval, err)
-					for event, err := range poller(ctx, client, req, pollingInterval) {
-						if err := handleStreamEntry(cfg, event, err); err != nil {
-							return err
-						}
+			if flags.stream {
+				ctx, debounceTimeout := utils.WithInactivityTimeout(baseCtx, cfg.timeout)
+
+				err = handleStreaming(ctx, cfg, client, req, debounceTimeout)
+				if err == nil {
+					return nil
+				}
+				if !errors.Is(err, a2a.ErrUnsupportedOperation) {
+					return utils.UnpackCause(ctx, err)
+				}
+
+				cfg.logf("falling back to polling (%v): %v", flags.pollingInterval, err)
+
+				for event, err := range poller(ctx, client, req, flags.pollingInterval) {
+					debounceTimeout()
+					if err := handleStreamEntry(cfg, event, err); err != nil {
+						return utils.UnpackCause(ctx, err)
 					}
 				}
 				return nil
 			}
+
+			ctx, cancel = context.WithTimeout(baseCtx, cfg.timeout)
+			defer cancel()
 
 			result, err := client.SendMessage(ctx, req)
 			if err != nil {
@@ -131,24 +107,58 @@ func newSendCmd(cfg *globalConfig, poller pollerFunc) *cobra.Command {
 	}
 
 	f := cmd.Flags()
-	f.BoolVar(&stream, "stream", false, "Use streaming response. Falls back to polling and synthetic events if a server does not support streaming.")
-	f.BoolVar(&async, "async", false, "Return immediately (fire-and-forget) instead of waiting for completion")
-	f.StringVar(&payload, "request-payload", "", "Full SendMessageRequest as a JSON file path or inline JSON string (mutually exclusive with the message-building flags)")
-	f.StringVar(&taskID, "task-id", "", "Task ID to continue an existing task")
-	f.StringVar(&contextID, "context-id", "", "Context ID to group this turn under")
-	f.IntVar(&history, "history", 0, "Request n history messages in the response")
-	f.DurationVar(&pollingInterval, "polling-interval", 5*time.Second, "Duration between GetTask requests in polling fallback mode.")
-	parts.Attach(f)
-	meta.Attach(f, "metadata", "Attach request metadata as a JSON object (repeatable)")
+	f.BoolVar(&flags.stream, "stream", false, "Use streaming response. Falls back to polling and synthetic events if a server does not support streaming.")
+	f.BoolVar(&flags.async, "async", false, "Return immediately (fire-and-forget) instead of waiting for completion")
+	f.StringVar(&flags.payload, "request-payload", "", "Full SendMessageRequest as a JSON file path or inline JSON string (mutually exclusive with the message-building flags)")
+	f.StringVar(&flags.taskID, "task-id", "", "Task ID to continue an existing task")
+	f.StringVar(&flags.contextID, "context-id", "", "Context ID to group this turn under")
+	f.IntVar(&flags.history, "history", 0, "Request n history messages in the response")
+	f.DurationVar(&flags.pollingInterval, "polling-interval", 5*time.Second, "Duration between GetTask requests in polling fallback mode.")
+	flags.parts.Attach(f)
+	flags.meta.Attach(f, "metadata", "Attach request metadata as a JSON object (repeatable)")
 
 	return cmd
 }
 
-func handleStreaming(ctx context.Context, cfg *globalConfig, client *a2aclient.Client, req *a2a.SendMessageRequest) error {
+func buildRequest(cmd *cobra.Command, cfg *globalConfig, flags *sendFlags, args []string) (*a2a.SendMessageRequest, error) {
+	if flags.payload != "" {
+		if err := ensureNoPayloadOverrides(cmd, args); err != nil {
+			return nil, err
+		}
+		req, err := parseRequestPayload(flags.payload)
+		if err != nil {
+			return nil, err
+		}
+		if req.Tenant == "" {
+			req.Tenant = cfg.tenant
+		}
+		return req, nil
+	}
+
+	msg, err := buildMessage(args, flags)
+	if err != nil {
+		return nil, err
+	}
+	req := &a2a.SendMessageRequest{Message: msg, Tenant: cfg.tenant}
+	flags.meta.ApplyTo(req)
+	if flags.async || cmd.Flags().Changed("history") {
+		req.Config = &a2a.SendMessageConfig{}
+		if flags.async {
+			req.Config.ReturnImmediately = true
+		}
+		if cmd.Flags().Changed("history") {
+			req.Config.HistoryLength = &flags.history
+		}
+	}
+	return req, nil
+}
+
+func handleStreaming(ctx context.Context, cfg *globalConfig, client *a2aclient.Client, req *a2a.SendMessageRequest, debounceTimeout utils.DebounceFunc) error {
 	if card := client.Card(); card != nil && !card.Capabilities.Streaming {
 		return fmt.Errorf("streaming not listed in agent capabilities: %w", a2a.ErrUnsupportedOperation)
 	}
 	for event, err := range client.SendStreamingMessage(ctx, req) {
+		debounceTimeout()
 		if err := handleStreamEntry(cfg, event, err); err != nil {
 			return err
 		}
@@ -166,12 +176,11 @@ func handleStreamEntry(cfg *globalConfig, event a2a.Event, err error) error {
 	return nil
 }
 
-func buildMessage(positional []string, partParser *flagparse.Parts) (*a2a.Message, error) {
-	parts, err := partParser.Parse()
+func buildMessage(positional []string, flags *sendFlags) (*a2a.Message, error) {
+	parts, err := flags.parts.Parse()
 	if err != nil {
 		return nil, err
 	}
-
 	if len(positional) > 1 {
 		return nil, fmt.Errorf("at most one positional argument is allowed, use --text-part for multi-part messages")
 	}
@@ -181,7 +190,14 @@ func buildMessage(positional []string, partParser *flagparse.Parts) (*a2a.Messag
 	if len(parts) == 0 {
 		return nil, fmt.Errorf("provide a message as text, or via --text-part, --file-part, --data-part, or --request-payload")
 	}
-	return a2a.NewMessage(a2a.MessageRoleUser, parts...), nil
+	msg := a2a.NewMessage(a2a.MessageRoleUser, parts...)
+	if flags.taskID != "" {
+		msg.TaskID = a2a.TaskID(flags.taskID)
+	}
+	if flags.contextID != "" {
+		msg.ContextID = flags.contextID
+	}
+	return msg, nil
 }
 
 // parseRequestPayload reads a full SendMessageRequest from ref, which is either

--- a/internal/cli/task_cancel.go
+++ b/internal/cli/task_cancel.go
@@ -40,11 +40,7 @@ func newTaskCancelCmd(cfg *globalConfig) *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("failed to create a client: %w", err)
 			}
-			defer func() {
-				if err := client.Destroy(); err != nil {
-					cfg.logf("failed to destroy client: %v", err)
-				}
-			}()
+			defer destroyClient(cfg, client)
 
 			req := &a2a.CancelTaskRequest{
 				ID:     a2a.TaskID(args[0]),

--- a/internal/cli/task_get.go
+++ b/internal/cli/task_get.go
@@ -39,11 +39,7 @@ func newTaskGetCmd(cfg *globalConfig) *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("failed to create a client: %w", err)
 			}
-			defer func() {
-				if err := client.Destroy(); err != nil {
-					cfg.logf("failed to destroy client: %v", err)
-				}
-			}()
+			defer destroyClient(cfg, client)
 
 			req := &a2a.GetTaskRequest{
 				ID:     a2a.TaskID(args[0]),

--- a/internal/cli/task_list.go
+++ b/internal/cli/task_list.go
@@ -49,11 +49,7 @@ func newTaskListCmd(cfg *globalConfig) *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("failed to create a client: %w", err)
 			}
-			defer func() {
-				if err := client.Destroy(); err != nil {
-					cfg.logf("failed to destroy client: %v", err)
-				}
-			}()
+			defer destroyClient(cfg, client)
 
 			req := &a2a.ListTasksRequest{
 				Tenant:           cfg.tenant,

--- a/internal/cli/task_subscribe.go
+++ b/internal/cli/task_subscribe.go
@@ -15,11 +15,11 @@
 package cli
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/spf13/cobra"
 
+	"github.com/a2aproject/a2a-cli/internal/utils"
 	"github.com/a2aproject/a2a-go/v2/a2a"
 )
 
@@ -29,19 +29,14 @@ func newTaskSubscribeCmd(cfg *globalConfig) *cobra.Command {
 		Short: "Subscribe to task events",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx, cancel := context.WithTimeout(cmd.Context(), cfg.timeout)
-			defer cancel()
-			ctx = withServiceParams(ctx, cfg)
+			ctx := withServiceParams(cmd.Context(), cfg)
+			ctx, debounceTimeout := utils.WithInactivityTimeout(ctx, cfg.timeout)
 
 			client, err := newAgentClient(ctx, cfg)
 			if err != nil {
 				return fmt.Errorf("failed to create a client: %w", err)
 			}
-			defer func() {
-				if err := client.Destroy(); err != nil {
-					cfg.logf("failed to destroy client: %v", err)
-				}
-			}()
+			defer destroyClient(cfg, client)
 
 			cfg.logf("subscribing to task %s", args[0])
 
@@ -49,8 +44,9 @@ func newTaskSubscribeCmd(cfg *globalConfig) *cobra.Command {
 				ID:     a2a.TaskID(args[0]),
 				Tenant: cfg.tenant,
 			}) {
+				debounceTimeout()
 				if err != nil {
-					return fmt.Errorf("subscription error: %w", err)
+					return utils.UnpackCause(ctx, err)
 				}
 				if err := cfg.PrintEvent(event); err != nil {
 					return fmt.Errorf("failed to print event: %w", err)

--- a/internal/clicfg/doc.go
+++ b/internal/clicfg/doc.go
@@ -12,6 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package config resolves a2a-cli configuration from environment variables and
-// .env (dotenv) files.
+// Package clicfg resolves a2a-cli configuration from environment variables
+// and .env (dotenv) files.
 package clicfg

--- a/internal/flagparse/transports.go
+++ b/internal/flagparse/transports.go
@@ -46,7 +46,7 @@ func SingleTransport(ss []string) (a2a.TransportProtocol, error) {
 		return "", err
 	}
 	if len(protos) != 1 {
-		return "", fmt.Errorf("--url requires exactly one --transport (rest, jsonrpc, or grpc)")
+		return "", fmt.Errorf("exactly one --transport is required (rest, jsonrpc, or grpc)")
 	}
 	return protos[0], nil
 }

--- a/internal/localsrv/serve_proxy.go
+++ b/internal/localsrv/serve_proxy.go
@@ -37,39 +37,40 @@ func ProxyLogInterceptorOption() a2aclient.FactoryOption {
 
 // ServeProxy runs a local A2A server that forwards every request to the given
 // upstream client, exposing the resolved (or supplied) agent card.
-func ServeProxy(ctx context.Context, sc Config, svcParams *flagparse.ServiceParams, client *a2aclient.Client, tenant string) error {
-	var card *a2a.AgentCard
-	if sc.CardPath != "" {
-		localCard, err := createAgentCard(sc.CardParams)
-		if err != nil {
-			return err
-		}
-		card = localCard
-	} else if clientCard := client.Card(); card != nil {
-		card = clientCard
-	} else {
-		extendedCard, err := client.GetExtendedAgentCard(ctx, &a2a.GetExtendedAgentCardRequest{Tenant: tenant})
-		if err != nil {
-			return fmt.Errorf("resolving upstream agent card: %w", err)
-		}
-		card = deriveProxyCard(extendedCard, sc.AdvertiseAddress, sc.Transport)
+func ServeProxy(ctx context.Context, cfg Config, svcParams *flagparse.ServiceParams, client *a2aclient.Client, tenant string) error {
+	card, err := resolveProxyCard(ctx, cfg, client, tenant)
+	if err != nil {
+		return err
 	}
 
 	handler := &proxyHandler{client: client, svcParams: svcParams}
 
-	if !sc.Quiet {
+	if !cfg.Quiet {
 		fmt.Fprintf(os.Stderr, "Proxying to %q agent\n", card.Name)
 	}
 
-	sc.Logger("proxy mode, transport=%s protocol=%s", sc.Transport, sc.ProtocolVersion)
+	cfg.Logger("proxy mode, transport=%s protocol=%s", cfg.Transport, cfg.ProtocolVersion)
 
-	return serve(ctx, sc, handler, card)
+	return serve(ctx, cfg, handler, card)
 }
 
-func deriveProxyCard(upstream *a2a.AgentCard, addr string, proto a2a.TransportProtocol) *a2a.AgentCard {
-	card := *upstream
-	card.SupportedInterfaces = []*a2a.AgentInterface{a2a.NewAgentInterface(addr, proto)}
-	return &card
+func resolveProxyCard(ctx context.Context, cfg Config, client *a2aclient.Client, tenant string) (*a2a.AgentCard, error) {
+	if cfg.CardPath != "" {
+		return createAgentCard(cfg.CardParams)
+	}
+
+	upstream := client.Card()
+	if upstream == nil {
+		fetched, err := client.GetExtendedAgentCard(ctx, &a2a.GetExtendedAgentCardRequest{Tenant: tenant})
+		if err != nil {
+			return nil, fmt.Errorf("resolving upstream agent card: %w", err)
+		}
+		upstream = fetched
+	}
+
+	cardCopy := *upstream
+	cardCopy.SupportedInterfaces = []*a2a.AgentInterface{getAgentInterface(cfg.CardParams)}
+	return &cardCopy, nil
 }
 
 type proxyHandler struct {

--- a/internal/localsrv/serve_test.go
+++ b/internal/localsrv/serve_test.go
@@ -18,6 +18,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -76,6 +78,53 @@ func TestLoadOrBuildCard_RequiredListFieldsNotNull(t *testing.T) {
 				t.Errorf("marshaled card key %q is %T; REQUIRED field must be a JSON array", key, val)
 			}
 		}
+	}
+}
+
+func TestCreateAgentCard_InterfaceURLScheme(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		params  CardParams
+		wantURL string
+	}{
+		{
+			name:    "rest defaults",
+			params:  CardParams{Transport: a2a.TransportProtocolHTTPJSON},
+			wantURL: "http://127.0.0.1",
+		},
+		{
+			name:    "rest without scheme",
+			params:  CardParams{Transport: a2a.TransportProtocolHTTPJSON, AdvertiseAddress: "127.0.0.1:9199"},
+			wantURL: "http://127.0.0.1:9199",
+		},
+		{
+			name:    "rest with scheme",
+			params:  CardParams{Transport: a2a.TransportProtocolHTTPJSON, AdvertiseAddress: "https://agents.com"},
+			wantURL: "https://agents.com",
+		},
+		{
+			name:    "grpc stays schemeless",
+			params:  CardParams{Transport: a2a.TransportProtocolGRPC, AdvertiseAddress: "127.0.0.1:9199"},
+			wantURL: "127.0.0.1:9199",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			card, err := createAgentCard(tc.params)
+			if err != nil {
+				t.Fatalf("createAgentCard() error = %v", err)
+			}
+			if len(card.SupportedInterfaces) != 1 {
+				t.Fatalf("createAgentCard() interfaces = %d, want 1", len(card.SupportedInterfaces))
+			}
+			if got := card.SupportedInterfaces[0].URL; got != tc.wantURL {
+				t.Fatalf("createAgentCard() interface URL = %q, want %q", got, tc.wantURL)
+			}
+		})
 	}
 }
 
@@ -204,12 +253,73 @@ func TestSplitByDelimiter(t *testing.T) {
 	}
 }
 
+func TestResolveProxyCard(t *testing.T) {
+	t.Parallel()
+
+	client := startTestServer(t, "Upstream Agent", NewEchoExecutor(), a2a.AgentCapabilities{})
+
+	path := filepath.Join(t.TempDir(), "card.json")
+	card, err := createAgentCard(CardParams{AgentName: "Custom"})
+	if err != nil {
+		t.Fatalf("createAgentCard() error = %v", err)
+	}
+	cardBytes, err := json.Marshal(card)
+	if err := os.WriteFile(path, cardBytes, 0o644); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	testCases := []struct {
+		name          string
+		params        CardParams
+		wantAddress   string
+		wantAgentName string
+	}{
+		{
+			name:          "reuses upstream card",
+			params:        CardParams{Transport: a2a.TransportProtocolHTTPJSON, AdvertiseAddress: "127.0.0.1:4242"},
+			wantAddress:   "http://127.0.0.1:4242",
+			wantAgentName: "Upstream Agent",
+		},
+		{
+			name:          "serves a custom card",
+			params:        CardParams{CardPath: path, Transport: a2a.TransportProtocolHTTPJSON},
+			wantAddress:   "http://127.0.0.1",
+			wantAgentName: "Custom",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			card, err := resolveProxyCard(t.Context(), Config{CardParams: tc.params}, client, "")
+			if err != nil {
+				t.Fatalf("resolveProxyCard() error = %v, want nil", err)
+			}
+			if card.Name != tc.wantAgentName {
+				t.Errorf("resolveProxyCard() card.Name = %q, want %q", card.Name, "Upstream Agent")
+			}
+			if len(card.SupportedInterfaces) != 1 {
+				t.Fatalf("resolveProxyCard() len(card.SupportedInterfaces) = %d, want 1", len(card.SupportedInterfaces))
+			}
+			gotAddress := card.SupportedInterfaces[0].URL
+			if card.SupportedInterfaces[0].URL != tc.wantAddress {
+				t.Errorf("resolveProxyCard() address = %q, want %q", gotAddress, tc.wantAddress)
+			}
+		})
+	}
+}
+
 func startExecTestServer(t *testing.T, command, chunk string) *a2aclient.Client {
+	t.Helper()
+	executor := newExecExecutor(command, chunk)
+	streaming := chunk != ""
+	return startTestServer(t, "Exec Test", executor, a2a.AgentCapabilities{Streaming: streaming})
+}
+
+func startTestServer(t *testing.T, name string, executor a2asrv.AgentExecutor, capabilities a2a.AgentCapabilities) *a2aclient.Client {
 	t.Helper()
 	ctx := t.Context()
 
-	executor := newExecExecutor(command, chunk)
-	streaming := chunk != ""
 	handler := a2asrv.NewHandler(executor)
 
 	mux := http.NewServeMux()
@@ -217,12 +327,12 @@ func startExecTestServer(t *testing.T, command, chunk string) *a2aclient.Client 
 	t.Cleanup(server.Close)
 
 	card := &a2a.AgentCard{
-		Name:    "Exec Test",
+		Name:    name,
 		Version: "1.0.0",
 		SupportedInterfaces: []*a2a.AgentInterface{
 			a2a.NewAgentInterface(server.URL, a2a.TransportProtocolHTTPJSON),
 		},
-		Capabilities: a2a.AgentCapabilities{Streaming: streaming},
+		Capabilities: capabilities,
 	}
 	mux.Handle(a2asrv.WellKnownAgentCardPath, a2asrv.NewStaticAgentCardHandler(card))
 	mux.Handle("/", a2asrv.NewRESTHandler(handler))

--- a/internal/localsrv/serve_test.go
+++ b/internal/localsrv/serve_test.go
@@ -257,16 +257,7 @@ func TestResolveProxyCard(t *testing.T) {
 	t.Parallel()
 
 	client := startTestServer(t, "Upstream Agent", NewEchoExecutor(), a2a.AgentCapabilities{})
-
-	path := filepath.Join(t.TempDir(), "card.json")
-	card, err := createAgentCard(CardParams{AgentName: "Custom"})
-	if err != nil {
-		t.Fatalf("createAgentCard() error = %v", err)
-	}
-	cardBytes, err := json.Marshal(card)
-	if err := os.WriteFile(path, cardBytes, 0o644); err != nil {
-		t.Fatalf("os.WriteFile() error = %v", err)
-	}
+	cardPath := mustWriteTmpCardFile(t, CardParams{AgentName: "Custom"})
 
 	testCases := []struct {
 		name          string
@@ -282,7 +273,7 @@ func TestResolveProxyCard(t *testing.T) {
 		},
 		{
 			name:          "serves a custom card",
-			params:        CardParams{CardPath: path, Transport: a2a.TransportProtocolHTTPJSON},
+			params:        CardParams{CardPath: cardPath, Transport: a2a.TransportProtocolHTTPJSON},
 			wantAddress:   "http://127.0.0.1",
 			wantAgentName: "Custom",
 		},
@@ -357,4 +348,21 @@ func execSendText(t *testing.T, client *a2aclient.Client, text string) *a2a.Task
 		t.Fatalf("client.SendMessage() result type = %T, want *a2a.Task", result)
 	}
 	return task
+}
+
+func mustWriteTmpCardFile(t *testing.T, params CardParams) string {
+	t.Helper()
+	card, err := createAgentCard(params)
+	if err != nil {
+		t.Fatalf("createAgentCard(%v) error = %v", params, err)
+	}
+	cardBytes, err := json.Marshal(card)
+	if err != nil {
+		t.Fatalf("json.Marshal(card) error = %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "card.json")
+	if err := os.WriteFile(path, cardBytes, os.ModePerm); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+	return path
 }

--- a/internal/localsrv/srv_card.go
+++ b/internal/localsrv/srv_card.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/a2aproject/a2a-go/v2/a2a"
 )
@@ -49,23 +50,27 @@ func createAgentCard(cfg CardParams) (*a2a.AgentCard, error) {
 	if cfg.AgentName != "" {
 		name = cfg.AgentName
 	}
-	var url string
-	if cfg.AdvertiseAddress != "" {
-		url = cfg.AdvertiseAddress
-	} else if cfg.Transport == a2a.TransportProtocolGRPC {
-		url = "127.0.0.1"
-	} else {
-		url = "http://127.0.0.1"
-	}
+
 	return &a2a.AgentCard{
 		Name:                name,
 		Description:         cfg.AgentDesc,
 		Version:             "1.0.0",
 		Capabilities:        a2a.AgentCapabilities{Streaming: true},
-		SupportedInterfaces: []*a2a.AgentInterface{a2a.NewAgentInterface(url, cfg.Transport)},
+		SupportedInterfaces: []*a2a.AgentInterface{getAgentInterface(cfg)},
 		// defaultInputModes, defaultOutputModes and skills are REQUIRED in the proto.
 		DefaultInputModes:  []string{"text"},
 		DefaultOutputModes: []string{"text"},
 		Skills:             []a2a.AgentSkill{},
 	}, nil
+}
+
+func getAgentInterface(cfg CardParams) *a2a.AgentInterface {
+	addr := cfg.AdvertiseAddress
+	if addr == "" {
+		addr = "127.0.0.1"
+	}
+	if cfg.Transport != a2a.TransportProtocolGRPC && !strings.Contains(addr, "://") {
+		addr = "http://" + addr
+	}
+	return a2a.NewAgentInterface(addr, cfg.Transport)
 }

--- a/internal/polling/polling.go
+++ b/internal/polling/polling.go
@@ -60,7 +60,12 @@ func Stream(ctx context.Context, client *a2aclient.Client, original *a2a.SendMes
 
 		successiveFailures := 0
 		for !prevState.Status.State.Terminal() && prevState.Status.State != a2a.TaskStateInputRequired {
-			time.Sleep(interval)
+			select {
+			case <-ctx.Done():
+				yield(nil, ctx.Err())
+				return
+			case <-time.After(interval):
+			}
 
 			task, err := client.GetTask(ctx, &a2a.GetTaskRequest{ID: tid, Tenant: req.Tenant})
 			if err != nil {

--- a/internal/polling/polling_test.go
+++ b/internal/polling/polling_test.go
@@ -21,6 +21,7 @@ import (
 	"iter"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 
@@ -183,6 +184,33 @@ func TestHandlePolling(t *testing.T) {
 				t.Fatalf("handlePolling() events wrong result (-want +got) diff = %s", diff)
 			}
 		})
+	}
+}
+
+func TestStream_SleepCancelledWithContext(t *testing.T) {
+	t.Parallel()
+
+	sleepTime := time.Hour // before the firtst Get
+	transport := &fakePollingTransport{
+		sendResult: &a2a.Task{Status: a2a.TaskStatus{State: a2a.TaskStateSubmitted}},
+	}
+	client := newPollingClient(t, transport)
+	req := &a2a.SendMessageRequest{Message: a2a.NewMessage(a2a.MessageRoleUser, a2a.NewTextPart("go"))}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	var gotErr error
+	for _, err := range Stream(ctx, client, req, sleepTime) {
+		if err != nil {
+			gotErr = err
+			break
+		}
+		cancel()
+	}
+
+	if !errors.Is(gotErr, context.Canceled) {
+		t.Fatalf("Stream() error = %v, want context.Canceled", gotErr)
 	}
 }
 

--- a/internal/utils/doc.go
+++ b/internal/utils/doc.go
@@ -1,0 +1,17 @@
+// Copyright 2026 The A2A Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package utils provides domain-agnostic helper functionality which
+// can be shared by different packages.
+package utils

--- a/internal/utils/errors.go
+++ b/internal/utils/errors.go
@@ -1,0 +1,28 @@
+// Copyright 2026 The A2A Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"context"
+	"errors"
+)
+
+// UnpackCause returns context.Cause if err is context.Canceled, or err otherwise.
+func UnpackCause(ctx context.Context, err error) error {
+	if errors.Is(err, context.Canceled) {
+		return context.Cause(ctx)
+	}
+	return err
+}

--- a/internal/utils/timeout.go
+++ b/internal/utils/timeout.go
@@ -1,0 +1,60 @@
+// Copyright 2026 The A2A Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// DebounceFunc resets a timeout when called.
+type DebounceFunc func()
+
+// WithInactivityTimeout derives a context from parent that is canceled when
+// DebounceFunc is not called within inactivity timeout d.
+func WithInactivityTimeout(parent context.Context, d time.Duration) (context.Context, DebounceFunc) {
+	if d <= 0 {
+		return parent, func() {}
+	}
+	ctx, cancel := context.WithCancelCause(parent)
+
+	resetCh := make(chan struct{}, 1)
+
+	go func() {
+		timer := time.NewTimer(d)
+		defer timer.Stop()
+		for {
+			select {
+			case <-parent.Done():
+				return
+
+			case <-resetCh:
+				timer.Reset(d)
+
+			case <-timer.C:
+				cancel(fmt.Errorf("no activity for %v", d.sho))
+				return
+			}
+		}
+	}()
+
+	return ctx, func() {
+		select {
+		case resetCh <- struct{}{}:
+		default:
+		}
+	}
+}

--- a/internal/utils/timeout.go
+++ b/internal/utils/timeout.go
@@ -45,7 +45,7 @@ func WithInactivityTimeout(parent context.Context, d time.Duration) (context.Con
 				timer.Reset(d)
 
 			case <-timer.C:
-				cancel(fmt.Errorf("no activity for %v", d.sho))
+				cancel(fmt.Errorf("no activity for %v", d))
 				return
 			}
 		}


### PR DESCRIPTION
* Fix timeout being applied to the whole streaming operation, change to inactivity timeout instead.
* Fix discrepancies of advertised address derivation in proxy server mode.
* Fix position argument not being used with `--extended` card of get card operation.
* Fix `poller` dependency not applied to `send` command because of late defaults injection.
* Fix `poller` being unresponsive to process interrupt signals during sleep. 
* Fix README drift from code and spec.