### PR TITLE
ci: add PR title, stale, and linked-issue workflows

### DIFF
--- a/.github/workflows/check-linked-issues.yml
+++ b/.github/workflows/check-linked-issues.yml
@@ -1,0 +1,31 @@
+name: Check for Linked Issues
+
+# Flags pull requests that don't reference an issue (e.g. "Closes #123"), so
+# every change is traceable back to a tracked feature request or bug.
+#
+# This is advisory: it does not block the merge, it only surfaces the count.
+# Release automation branches are excluded so they never trip the check.
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  check_pull_requests:
+    runs-on: ubuntu-latest
+    name: Check linked issues
+    permissions:
+      issues: read
+      pull-requests: write
+    steps:
+      - uses: nearform-actions/github-action-check-linked-issues@7140e2e01aa0c18b8ac61bddf5e89abde1ca760e # v1
+        id: check-linked-issues
+        with:
+          exclude-branches: 'release/**, dependabot/**, release-please--branches--main'
+          comment: false
+
+      - name: Report linked-issue count
+        run: echo "Linked issues on this PR - ${{ steps.check-linked-issues.outputs.linked_issues_count }}"

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,0 +1,63 @@
+name: "Conventional Commits"
+
+# Enforce one simple rule: every pull request title must follow the
+# Conventional Commits spec (https://www.conventionalcommits.org/).
+#
+# Why it matters here: this repo squash-merges, so the PR title becomes the
+# commit message, and release-please (release-type: go, see release-please.yaml)
+# reads those commits to version the CLI and generate the changelog. A well-formed
+# title => correct version bump + clean changelog.
+#
+# Picking a type (see CONTRIBUTING.md):
+#   feat / fix   -> CLI code            e.g. "feat: add subscribe command"
+#   docs(spec)   -> specification/SPEC.md or COMPLIANCE.md
+#   docs         -> any other docs      e.g. "docs: clarify README install steps"
+#   chore/ci/... -> tooling, config, tests, refactors
+
+on:
+  # pull_request_target so the check also runs on PRs from forks (this is a
+  # public repo). Safe here because this workflow never checks out or runs any
+  # PR-authored code — it only reads the PR title from the event payload.
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
+
+permissions:
+  contents: read
+
+jobs:
+  validate-pr-title:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Allowed types (the Conventional Commits standard set).
+          types: |
+            feat
+            fix
+            docs
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+            style
+          # Scope is optional and free-form, so `docs(spec):`, `feat(cli):`, or no
+          # scope at all are all accepted.
+          requireScope: false
+          # Good-title hygiene: subject starts lowercase and has no trailing period.
+          # (Optional — delete these two lines if you'd rather not enforce it.)
+          subjectPattern: ^(?![A-Z]).+[^.]$
+          subjectPatternError: |
+            The subject "{subject}" in PR title "{title}" should start with a
+            lowercase letter and must not end with a period.

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,52 @@
+# Warns, then closes, issues and PRs that have gone quiet, so the tracker
+# reflects work that is actually live. Only issues explicitly waiting on the
+# author (see any-of-labels) are eligible; add the `override-stale` label to
+# any issue or PR that should never be auto-closed.
+#
+# Docs: https://github.com/actions/stale
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+    # 22:30 UTC daily (15:30 PDT / 14:30 PST)
+    - cron: "30 22 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+      actions: write
+
+    steps:
+      - uses: actions/stale@1e223db275d687790206a7acac4d1a11bd6fe629 # v10
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-issue-stale: 14
+          days-before-issue-close: 13
+          stale-issue-label: "status:stale"
+          close-issue-reason: not_planned
+          any-of-labels: "status:awaiting response,status:more data needed"
+          stale-issue-message: >
+            Marking this issue as stale since it has been open for 14 days with no activity.
+            This issue will be closed if no further activity occurs.
+          close-issue-message: >
+            This issue was closed because it has been inactive for 27 days.
+            Please post a new issue if you need further assistance. Thanks!
+          days-before-pr-stale: 14
+          days-before-pr-close: 13
+          stale-pr-label: "status:stale"
+          stale-pr-message: >
+            Marking this pull request as stale since it has been open for 14 days with no activity.
+            This PR will be closed if no further activity occurs.
+          close-pr-message: >
+            This pull request was closed because it has been inactive for 27 days.
+            Please open a new pull request if you need further assistance. Thanks!
+          # Labels that exempt an issue/PR from being marked stale.
+          exempt-issue-labels: "override-stale"
+          exempt-pr-labels: "override-stale"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,3 +43,19 @@ We use GitHub pull requests for reviews. See [GitHub Help](https://help.github.c
 6. **Resolve feedback** — work with reviewers to address comments.
 
 Be patient — reviewing and merging a pull request can take time.
+
+### Pull request tips
+
+A few checks run on every pull request. Follow these tips to pass them:
+
+- Add tests for every new feature.
+- Open an issue first, then link it in the PR. For example: `Fixes #123` or `Closes #123`.
+- Use Conventional Commits for commit messages and PR titles.
+- For code changes, run these before you push:
+
+  ```sh
+  go mod tidy -diff
+  go build ./...
+  go test -race ./...
+  golangci-lint run
+  ```


### PR DESCRIPTION
Closes #38

Adds three community-ops GitHub workflows and documents them.

- **conventional-commits** — lint PR titles so release-please versions correctly.
- **stale** — auto-triage inactive issues and PRs.
- **check-linked-issues** — advisory check that a PR links an issue.
- **CONTRIBUTING** — a short "Pull request tips" section on the PR checks.

All third-party actions are pinned to commit SHAs.

**Prerequisite for stale.yaml:** create these labels first, or it marks nothing (safe no-op): `status:stale`, `status:awaiting response`, `status:more data needed`, `override-stale`.