### PR TITLE
docs: fix a2a skill setup and binary naming

### DIFF
--- a/skills/a2a-cli/README.md
+++ b/skills/a2a-cli/README.md
@@ -13,11 +13,19 @@ It is one file, `SKILL.md`. Once it is installed, your agent can:
 
 ## Prerequisite
 
-The skill drives the `a2a` binary; it does not install it. Install `a2a` first:
+The skill drives the `a2a` binary; it does not install it. With a Go toolchain
+matching the repository's `go.mod`, build it from source with the expected name:
 
 ```bash
-go install github.com/a2aproject/a2a-cli@latest
+git clone https://github.com/a2aproject/a2a-cli.git
+cd a2a-cli
+go build -o a2a .
+export PATH="$PWD:$PATH"
 ```
+
+The PATH change applies to this shell. For future sessions, place the binary in
+a directory on your PATH. A plain `go install` names the executable `a2a-cli`,
+whereas this skill invokes `a2a`.
 
 Confirm it is on your `PATH`:
 

--- a/skills/a2a-cli/SKILL.md
+++ b/skills/a2a-cli/SKILL.md
@@ -41,12 +41,16 @@ returned.
 
 ## Setup
 
-Check for the binary; install from source if missing (needs a Go toolchain from
-https://go.dev/doc/install); re-run to update:
+Check that the binary is available:
 
 ```bash
-go install github.com/a2aproject/a2a-cli@latest
+a2a version
 ```
+
+If it is missing, ask the user to install it using the
+[setup instructions](https://github.com/a2aproject/a2a-cli/blob/main/skills/a2a-cli/README.md#prerequisite),
+then retry the check. The binary must be available as `a2a` on PATH; the skill
+does not install or update it.
 
 The tool is under active development. Treat `a2a help` and `a2a <command>
 --help` as the source of truth for the current commands and flags.


### PR DESCRIPTION
# Description

The skill's documented `go install` command creates an executable named `a2a-cli`, while its examples and verification step invoke `a2a`. Build explicitly with `go build -o a2a .` and explain the PATH setup. Replace the skill's automatic installation instruction with an `a2a version` preflight and a link to the setup instructions.

This PR targets `skill/a2a-cli` so the two-file correction can be incorporated into #27. It implements the [previously posted patch](https://github.com/a2aproject/a2a-cli/pull/27#issuecomment-5571802275). Related issue: #4.

## Validation

- Reproduced the exact latest-version installation in an isolated GOBIN: it creates `a2a-cli`. Latest resolved to `v0.0.0-20260904130516-a27e1ee6d332`.
- Verified the explicit build, PATH setup and `a2a version` against PR #27's head on macOS arm64 with Go 1.26.0.
- `git diff --check` passes.

## Which area does this relate to?

- [ ] CLI code
- [ ] SPEC or COMPLIANCE file
- [x] Other doc files

## Checklist

- [x] Reviewed the contributing guide.
- [x] Conventional Commits title.
- [x] Appropriate docs updated.

Go formatting, unit tests and lint are not applicable to this documentation-only change.

## Maintainer action

The linked-issue check requires a GitHub closing-issue association. This correction targets the feature branch for #27, and my account cannot add that association. Please link this PR to the existing issue #4 using the repository's preferred process.
